### PR TITLE
Add metrics name to metrics port (currently svc port +3)

### DIFF
--- a/charts/app-mendix/Chart.yaml
+++ b/charts/app-mendix/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: app-mendix
-version: 1.0.6
+version: 1.0.7
 description: Mendix Application Chart.
 icon: https://cinaq.github.io/helm-charts/icons/mendix-logo.png
 maintainers:

--- a/charts/app-mendix/templates/deployment.yaml
+++ b/charts/app-mendix/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
             {{- if .Values.metrics.enabled }}
             - containerPort: {{ add .Values.service.internalPort 3}}
+              name: metrics
             {{- end }}
           env:
             - name: CF_INSTANCE_INDEX


### PR DESCRIPTION
allows for loose coupling when defining pod monitor, which can now just refer to port name "metrics" instead of port number.