### PR TITLE
Switch to startupProbe for more efficient startup time. Apps have by …

### DIFF
--- a/charts/app-mendix/Chart.yaml
+++ b/charts/app-mendix/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: app-mendix
-version: 3.0.8
+version: 3.0.9
 description: Mendix Application Chart.
 icon: https://cinaq.github.io/helm-charts/icons/mendix-logo.png
 maintainers:

--- a/charts/app-mendix/README.md
+++ b/charts/app-mendix/README.md
@@ -1,10 +1,10 @@
 # app-mendix
 
-![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square)
 
 Mendix Application Chart.
 
-This Helm chart simplifies the deployment and management of Mendix applications on Kubernetes clusters. It provides a standardized packaging format and streamlines deployments across development, staging, and production environments. Key features include configuration of resource requirements, integration with secrets management, and health checks for improved application resilience.
+This Helm chart simplifies the deployment and management of Mendix applications on Kubernetes clusters. It provides a standardized packaging format and streamlines deployments across development, staging, and production environments. Key features include configuration of resource requirements, integration with secrets management, and improved application resilience through startup, readiness and liveness probes.
 
 
 Add `cinaq` repository
@@ -30,77 +30,61 @@ helm upgrade my-app cinaq/app-mendix --set replicaCount=2
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| annotations | object | `{}` |  |
-| autoscale.enabled | bool | `false` |  |
-| autoscale.maxSlaveReplicas | int | `3` |  |
-| autoscale.minSlaveReplicas | int | `1` |  |
-| autoscale.targetCPUUtilizationPercentage | int | `70` |  |
-| env | list | `[]` |  |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"cinaq/hackme"` |  |
-| image.tag | string | `"latest"` |  |
-| imagePullSecrets[0].name | string | `"dockerconfigjson"` |  |
-| ingress.addHosts | bool | `false` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.domain | string | `"app.example.com"` |  |
-| ingress.enabled | bool | `true` |  |
-| ingress.hosts | list | `[]` |  |
-| ingress.ingressClassName | string | `"nginx"` |  |
-| ingress.tls.enabled | bool | `false` |  |
-| ingress.tls.secretName | string | `"secret-tls"` |  |
-| licenseId | string | `nil` |  |
-| licenseKey | string | `nil` |  |
-| lifecycle.prestop.command | string | `"/opt/eap/bin/stop.sh"` |  |
-| lifecycle.prestop.enabled | bool | `false` |  |
-| livenessProbe.enabled | bool | `true` |  |
-| livenessProbe.exec.command | string | `nil` |  |
-| livenessProbe.failureThreshold | int | `3` |  |
-| livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | int | `8080` |  |
-| livenessProbe.initialDelaySeconds | int | `200` |  |
-| livenessProbe.periodSeconds | int | `20` |  |
-| livenessProbe.successThreshold | int | `1` |  |
-| livenessProbe.tcpSocket.port | string | `nil` |  |
-| livenessProbe.timeoutSeconds | int | `1` |  |
-| livenessProbe.type | string | `"httpGet"` |  |
-| metrics.enabled | bool | `true` |  |
-| metrics.runtimeLoginMetricsEnabled | bool | `true` |  |
-| metrics.trendsForwarderUrl | string | `""` |  |
-| networkPolicy.enabled | bool | `true` |  |
-| networkPolicy.ingress.allowed | bool | `true` |  |
-| nodeSelector | object | `{}` |  |
-| persistence.enabled | bool | `false` |  |
-| persistence.extraVolumeMounts | list | `[]` |  |
-| persistence.extraVolumes | list | `[]` |  |
-| persistence.nfsVolume.enabled | bool | `false` |  |
-| persistence.nfsVolume.name | string | `"mendix-nfs"` |  |
-| persistence.nfsVolume.path | string | `"/mnt/mendixdata"` |  |
-| persistence.nfsVolume.server | string | `"nfs.example.com"` |  |
-| persistence.nfsVolume.storage | string | `"10Gi"` |  |
-| persistence.nfsVolume.subPath | string | `"/app"` |  |
-| readinessProbe.enabled | bool | `true` |  |
-| readinessProbe.exec.command | string | `nil` |  |
-| readinessProbe.failureThreshold | int | `3` |  |
-| readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | int | `8080` |  |
-| readinessProbe.initialDelaySeconds | int | `120` |  |
-| readinessProbe.periodSeconds | int | `10` |  |
-| readinessProbe.successThreshold | int | `1` |  |
-| readinessProbe.tcpSocket.port | string | `nil` |  |
-| readinessProbe.timeoutSeconds | int | `1` |  |
-| readinessProbe.type | string | `"httpGet"` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| route.annotations | object | `{}` |  |
-| route.enabled | bool | `false` |  |
-| route.host | string | `"app.example.com"` |  |
-| route.tls.enabled | bool | `false` |  |
-| secretName | string | `""` |  |
-| service.externalPort | int | `80` |  |
-| service.internalPort | int | `8080` |  |
-| service.type | string | `"ClusterIP"` |  |
-| tolerations | list | `[]` |  |
+| affinity | object | `{}` | Pod affinity settings |
+| annotations | object | `{}` | Pod annotations |
+| autoscale.enabled | bool | `false` | Enable horizontal pod autoscaling |
+| autoscale.maxSlaveReplicas | int | `3` | Maximum number of slave replicas |
+| autoscale.minSlaveReplicas | int | `1` | Minimum number of slave replicas |
+| autoscale.targetCPUUtilizationPercentage | int | `70` | Target CPU utilization percentage for scaling |
+| env | list | `[]` | List of environment variables |
+| image.pullPolicy | string | `"Always"` | Image pull policy |
+| image.repository | string | `"cinaq/hackme"` | Docker image repository |
+| image.tag | string | `"latest"` | Docker image tag |
+| imagePullSecrets[0].name | string | `"dockerconfigjson"` | Name of the image pull secret |
+| ingress.addHosts | bool | `false` | Add additional hosts to ingress |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.domain | string | `"app.example.com"` | Default domain for ingress |
+| ingress.enabled | bool | `true` | Enable ingress |
+| ingress.hosts | list | `[]` | List of additional ingress hosts |
+| ingress.ingressClassName | string | `"nginx"` | Ingress class name |
+| ingress.tls.enabled | bool | `false` | Enable TLS for ingress |
+| ingress.tls.secretName | string | `"secret-tls"` | TLS secret name |
+| licenseId | string | `nil` | Mendix license ID |
+| licenseKey | string | `nil` | Mendix license key |
+| lifecycle.prestop.command | string | `"/opt/eap/bin/stop.sh"` | Command to run before stopping container |
+| lifecycle.prestop.enabled | bool | `false` | Enable prestop lifecycle hook |
+| metrics.enabled | bool | `true` | Enable metrics collection |
+| metrics.runtimeLoginMetricsEnabled | bool | `true` | Enable runtime login metrics |
+| metrics.trendsForwarderUrl | string | `""` | URL for forwarding metrics trends (e.g. Loki endpoint) |
+| networkPolicy.enabled | bool | `true` | Enable network policy |
+| networkPolicy.ingress.allowed | bool | `true` | Allow ingress traffic |
+| nodeSelector | object | `{}` | Node selector for pod assignment |
+| persistence.enabled | bool | `false` | Enable persistence for application data |
+| persistence.extraVolumeMounts | list | `[]` | Additional volume mounts |
+| persistence.extraVolumes | list | `[]` | Additional volumes |
+| persistence.nfsVolume.enabled | bool | `false` | Enable NFS volume |
+| persistence.nfsVolume.name | string | `"mendix-nfs"` | Name of the NFS volume |
+| persistence.nfsVolume.path | string | `"/mnt/mendixdata"` | Path on the NFS server |
+| persistence.nfsVolume.server | string | `"nfs.example.com"` | NFS server address |
+| persistence.nfsVolume.storage | string | `"10Gi"` | Storage size for NFS volume |
+| persistence.nfsVolume.subPath | string | `"/app"` | Subpath within the volume |
+| livenessProbe.failureThreshold | int | `18` | Maximum number of failures before container is restarted |
+| livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |
+| readinessProbe.failureThreshold | int | `30` | Maximum number of failures before pod is marked as not ready |
+| readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |
+| startupProbe.failureThreshold | int | `1080` | Maximum number of failures before giving up (allows up to 3 hours for startup) |
+| startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |
+| replicaCount | int | `1` | Number of replicas |
+| resources | object | `{}` | CPU/Memory resource requests/limits |
+| route.annotations | object | `{}` | OpenShift route annotations |
+| route.enabled | bool | `false` | Enable OpenShift route |
+| route.host | string | `"app.example.com"` | OpenShift route host |
+| route.tls.enabled | bool | `false` | Enable TLS for OpenShift route |
+| secretName | string | `""` | Name of the secret containing environment variables |
+| service.externalPort | int | `80` | External port for the service |
+| service.internalPort | int | `8080` | Internal port for the service |
+| service.type | string | `"ClusterIP"` | Kubernetes service type |
+| tolerations | list | `[]` | Node tolerations |
 
 ## Maintainers
 

--- a/charts/app-mendix/templates/statefulset.yaml
+++ b/charts/app-mendix/templates/statefulset.yaml
@@ -66,50 +66,31 @@ spec:
             - secretRef:
                 name: {{ .Values.secretName }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            {{- if eq "httpGet" .Values.readinessProbe.type }}
+          startupProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.httpGet.path }}
-              port: {{ .Values.readinessProbe.httpGet.port }}
-            {{- else if eq "exec" .Values.readinessProbe.type }}
-            exec:
-              command:
-              {{- range .Values.readinessProbe.exec.command }}
-              - {{ . }}
-              {{- end }}
-            {{- else if eq "tcpSocket" .Values.readinessProbe.type }}
-            tcpSocket:
-              port: {{ .Values.readinessProbe.tcpSocket.port }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
+              path: /
+              port: 8080
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          
+          # Start liveness checks only after the startupProbe succeeds.
+          # if this fails, the container is restarted
           livenessProbe:
-            {{- if eq "httpGet" .Values.livenessProbe.type }}
             httpGet:
-              path: {{ .Values.livenessProbe.httpGet.path }}
-              port: {{ .Values.livenessProbe.httpGet.port }}
-            {{- else if eq "exec" .Values.livenessProbe.type }}
-            exec:
-              command:
-              {{- range .Values.livenessProbe.exec.command }}
-              - {{ . }}
-              {{- end }}
-            {{- else if eq "tcpSocket" .Values.livenessProbe.type }}
-            tcpSocket:
-              port: {{ .Values.livenessProbe.tcpSocket.port }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              path: /
+              port: 8080
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          {{- end }}
+
+          # Start readiness checks after startupProbe succeeds.
+          # If this fails, the Pod is removed from the Service endpoint list.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+
           {{- if .Values.lifecycle.prestop.enabled }}
           lifecycle:
             preStop:

--- a/charts/app-mendix/values.yaml
+++ b/charts/app-mendix/values.yaml
@@ -107,37 +107,21 @@ autoscale:
   maxSlaveReplicas: 3
   targetCPUUtilizationPercentage: 70
 
-readinessProbe:
-  enabled: true
-  type: httpGet
-  httpGet:
-    path: /
-    port: 8080
-  exec: 
-    command:
-  tcpSocket:
-    port:
-  initialDelaySeconds: 180
-  periodSeconds: 30
-  failureThreshold: 40
-  timeoutSeconds: 10
-  successThreshold: 1
+# available from kubernetes 1.20+
+# max 3 hours
+startupProbe:
+  failureThreshold: 1080
+  periodSeconds: 10
 
+# max 5 minutes
+readinessProbe:
+  periodSeconds: 10
+  failureThreshold: 30
+
+# max 3 minutes
 livenessProbe:
-  enabled: true
-  type: httpGet
-  httpGet:
-    path: /
-    port: 8080
-  exec: 
-    command:
-  tcpSocket:
-    port:
-  initialDelaySeconds: 180
-  periodSeconds: 30
-  failureThreshold: 40
-  timeoutSeconds: 10
-  successThreshold: 1
+  periodSeconds: 10
+  failureThreshold: 18
 
 lifecycle:
   prestop:


### PR DESCRIPTION
…default 3 hours maximum time to migrate data if needed

This change also simplifies the probe logic. It makes little sense to expose the details/flexibility in `values.yaml` other than allowing longer or shorter waiting time. The default should work fine for 99% of cases.

