### PR TITLE
ci: add release-please for Helm charts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,11 @@
+{
+  "charts/lowops-platform": "0.1.24",
+  "charts/app-nextjs": "0.1.3",
+  "charts/app-mendix": "3.0.9",
+  "charts/app-generic": "0.1.6",
+  "charts/kanister-profile": "0.112.0",
+  "charts/retraced": "0.1.3",
+  "charts/kanister-actionset": "0.1.1",
+  "charts/kanister-blueprint": "0.1.0",
+  "charts/loki-stack": "2.6.3"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,40 @@
+{
+  "packages": {
+    "charts/lowops-platform": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/app-nextjs": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/app-mendix": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/app-generic": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/kanister-profile": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/retraced": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/kanister-actionset": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/kanister-blueprint": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    },
+    "charts/loki-stack": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "helm"
+    }
+  }
+}


### PR DESCRIPTION
Configure manifest-mode release-please with helm release type per chart so version bumps and changelogs align with chart-releaser on main.
