### PR TITLE
fix: align release-please manifest and Chart.yaml with main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-  "charts/lowops-platform": "0.1.24",
-  "charts/app-nextjs": "0.1.3",
-  "charts/app-mendix": "3.0.9",
-  "charts/app-generic": "0.1.6",
+  "charts/lowops-platform": "0.1.27",
+  "charts/app-nextjs": "0.4.1",
+  "charts/app-mendix": "3.3.1",
+  "charts/app-generic": "0.4.1",
   "charts/kanister-profile": "0.112.0",
   "charts/retraced": "0.1.3",
   "charts/kanister-actionset": "0.1.1",

--- a/charts/app-generic/Chart.yaml
+++ b/charts/app-generic/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: app-generic
 description: A Helm chart for deploying a generic applications on low-ops platform
 type: application
-version: 0.1.6
+version: 0.4.1
 appVersion: "1.0.0"

--- a/charts/app-mendix/Chart.yaml
+++ b/charts/app-mendix/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: app-mendix
-version: 3.0.9
+version: 3.3.1
 description: Mendix Application Chart.
 icon: https://cinaq.github.io/helm-charts/icons/mendix-logo.png
 maintainers:

--- a/charts/app-nextjs/Chart.yaml
+++ b/charts/app-nextjs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: app-nextjs
 description: A Helm chart for deploying a nextjs applications on low-ops platform
 type: application
-version: 0.1.3
+version: 0.4.1
 appVersion: "1.0.0"

--- a/charts/lowops-platform/Chart.yaml
+++ b/charts/lowops-platform/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lowops-platform
 description: A Helm chart for Low Ops Platform installation
 type: application
-version: 0.1.24
-appVersion: 4.2.1
+version: 0.1.27
+appVersion: 4.5.0


### PR DESCRIPTION
Bump manifest entries and chart versions to match origin/main so release-please computes the next semver from the actually released versions (avoids downgrades like 0.4.1 -> 0.2.0).
